### PR TITLE
Null data should be {}

### DIFF
--- a/firebase-element.html
+++ b/firebase-element.html
@@ -270,6 +270,8 @@ Example:
     },
     _setData: function(data) {
       this.closeObserver();
+      if (data === null)
+        data = {};
       this.data = this._data = data;
       this.observeData();
     },


### PR DESCRIPTION
My firebase schema is:
    /users
        $userId
            account
                street
                city
                state
Initially, /users/$uid/account key does not exist
firebase-element is bound to this non-existent /users/$uid/account.
my template paper-inputs are bound to {{firebase-element.data.street}}, city, state

The bug is that my edits are not getting saved to firebase. This happens because firebase-element.data is null, and writes to null[street] fail.

My fix is to represent null data as {}. This fixes my bug, but I am not sure what other side effects it might have.
