### PR TITLE
Fixed Firebase dependency in Bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,6 +3,6 @@
   "private": true,
   "dependencies": {
     "polymer": "Polymer/polymer#master",
-    "firebase": "*"
+    "firebase": "1.1.x"
   }
 }


### PR DESCRIPTION
The Firebase dependency in the `bower.json` file was just set to `*`, which is generally a bad idea and also screwed things up a bit when Firebase updated to 2.0.x. In general, `*` shouldn't be used as major version changes are expected to have breaking changes. This reverts the library back to `1.1.x` and fixes #19.

cc/ @chuckh
