### PR TITLE
fix closeQuery to only close itself

### DIFF
--- a/firebase-element.html
+++ b/firebase-element.html
@@ -341,7 +341,10 @@ Example:
     },
     closeQuery: function() {
       if (this.query) {
-        this.query.off();
+        this.query.off('child_added', this.childAdded, this);
+        this.query.off('child_changed', this.childChanged, this);
+        this.query.off('child_moved', this.childMoved, this);
+        this.query.off('child_removed', this.childRemoved, this);
       }
     },
     //


### PR DESCRIPTION
Issue:
If you have two webcomponents on the same page, each with a firebase-element listening to the same path, when one is removed, it will shutdown the listeners on the other.

Solution:
```this.query.off();``` called with no parameters closes all Firebase listeners at that location. It should instead be called with the original eventType, callback and context passed in. (https://www.firebase.com/docs/web/api/query/off.html). 

Additional Mess:
Unfortunately an additional bug in Firebase (https://github.com/firebase/firebase-bower/issues/6) means that until both bugs are fixed, the symptoms above will still exist. Firebase should compare the contexts to know that two listeners are different, but doesn't do that for the ChildEvent Listeners.