### PR TITLE
Fix keys being out of sync

### DIFF
--- a/firebase-element.html
+++ b/firebase-element.html
@@ -452,9 +452,7 @@ Example:
     },
     dataChange: function() {
       //this.job('change', function() {
-        if (this.data) {
-          this.keys = this.data ? Object.keys(this.data) : [];
-        }
+        this.keys = this.data ? Object.keys(this.data) : [];
         this.fire('data-change');
       //});
     },


### PR DESCRIPTION
`keys` property is out sync when you remove last child, they do not get reset because `data==null`. Looks like a simple oversight.