### PR TITLE
Fire data-ready event on loaded data

### DIFF
--- a/firebase-element.html
+++ b/firebase-element.html
@@ -136,6 +136,13 @@ Example:
        *
        * @event data-change
        */
+       
+      /**
+       * Fired when the remote location has been read, whether or not data
+       * has been returned.
+       * 
+       * @event data-ready
+       */
 
       /**
        * Fired when an error occurs on an interaction with Firebase.  The
@@ -320,6 +327,7 @@ Example:
       this.log && console.log('acquired value ' + this.location);
       this.dataReady = true;
       this._setData(snapshot.val());
+      this.fire('data-ready', this.data);
       if (this.data) {
         this.dataChange();
       }


### PR DESCRIPTION
There's often a need to know when data has been read from the Firebase for the first time (e.g. to initialize an empty object), and while dataReady gives us this, there's presently no event fired to let us know "hey, we read the Firebase, nothing here."